### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/fedorgorokhovik/7ca4808e-c080-41c3-91c4-d75f4aac5903/60945be6-d93e-48f0-9729-b9fb3b1cd7d0/_apis/work/boardbadge/6ca199c7-48ac-4640-a956-007f867ffbbc)](https://dev.azure.com/fedorgorokhovik/7ca4808e-c080-41c3-91c4-d75f4aac5903/_boards/board/t/60945be6-d93e-48f0-9729-b9fb3b1cd7d0/Microsoft.RequirementCategory)
 # CodeIceFire


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/fedorgorokhovik/7ca4808e-c080-41c3-91c4-d75f4aac5903/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.